### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@
 ## Installation
 Fast installation is possible through [brew](https://brew.sh/) on Linux or MacOS.
 
-```
-brew tap skatkov/tap && brew install skatkov/tap/stoic
-```
+`brew install skatkov/tap/stoic`
 
 If you want to download executable on your own, then there is another 📥 [Installation](INSTALL.md) instruction that comes with release.
 


### PR DESCRIPTION
- `brew install` will tap and install w/o a separate `brew tap`

```shell
brew install skatkov/tap/stoic 
==> Tapping skatkov/tap
Cloning into '/opt/homebrew/Library/Taps/skatkov/homebrew-tap'...
remote: Enumerating objects: 93, done.
remote: Counting objects: 100% (93/93), done.
remote: Compressing objects: 100% (76/76), done.
remote: Total 93 (delta 30), reused 11 (delta 3), pack-reused 0
Receiving objects: 100% (93/93), 18.08 KiB | 4.52 MiB/s, done.
Resolving deltas: 100% (30/30), done.
Tapped 2 formulae (15 files, 29.2KB).
==> Downloading https://formulae.brew.sh/api/formula.jws.json
############################################################################################################################################## 100.0%
==> Fetching skatkov/tap/stoic
==> Downloading https://github.com/skatkov/stoic/archive/refs/tags/0.6.tar.gz
==> Downloading from https://codeload.github.com/skatkov/stoic/tar.gz/refs/tags/0.6
#=#=- #    #                                                                                                                                        
==> Installing stoic from skatkov/tap
==> go build
==> Downloading https://formulae.brew.sh/api/cask.jws.json
############################################################################################################################################## 100.0%
🍺  /opt/homebrew/Cellar/stoic/0.6: 6 files, 4.1MB, built in 6 seconds
==> Running `brew cleanup stoic`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```