### PR TITLE
Update missing URL in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,16 +7,18 @@ notifications on [Github](https://github.com/skatkov/stoic) (at the top right:
 ## MacOS
 
 1. Download the latest version and unzip
-   - [**Download for Intel**](https://github.com/skatkov/stoic/releases/latest/download/stoic-mac-intel.zip)
-   - [**Download for M1 (ARM)**](https://github.com/skatkov/stoic/releases/latest/download/stoic-mac-arm.zip)
+   - [**Download for Intel**](https://github.com/skatkov/stoic/releases/latest/download/stoic_Darwin_x86_64.tar.gz)
+   - [**Download for M1 (ARM)**](https://github.com/skatkov/stoic/releases/latest/download/stoic_Darwin_arm64.tar.gz)
 2. Right-click on the binary and select “Open“
    (due to [Gatekeeper](https://support.apple.com/en-us/HT202491))
 3. Copy to path, e.g. `mv stoic /usr/local/bin/stoic` (might require `sudo`)
 
 ## Linux
 
-1. [**Download**](https://github.com/skatkov/stoic/releases/latest/download/stoic-linux.zip)
-   the latest version and unzip
+1. Download the latest version and unzip
+   - [**Download for Intel (x86_64)**](https://github.com/skatkov/stoic/releases/latest/download/stoic_Linux_x86_64.tar.gz)
+   - [**Download for Intel (i386)**](https://github.com/skatkov/stoic/releases/latest/download/stoic_Linux_i386.tar.gz)
+   - [**Download for ARM**](https://github.com/skatkov/stoic/releases/latest/download/stoic_Linux_arm64.tar.gz)
 2. Copy to path, e.g. `mv stoic /usr/local/bin/stoic` (might require `sudo`)
 
 ## Windows


### PR DESCRIPTION
Current URLs are only found in ~[0.5](https://github.com/skatkov/stoic/releases/tag/0.5).
Since 0.6.1, [appear](https://github.com/skatkov/stoic/releases/tag/0.6.1) with different suffix.

Follow a22533a1b10bfbbcf6af640f13d4cc08caad791b and changes since 0.6.1

https://github.com/skatkov/stoic/compare/0.6...0.6.1